### PR TITLE
CI 실패시 코멘트 달기

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,4 +10,4 @@ async fn main() {
     let repo_url = "https://github.com/reddevilmidzy/redddy-action";
     let interval_duration = Duration::from_secs(60);
     check_repository_links(repo_url, interval_duration).await;
-} 
+}


### PR DESCRIPTION
## ♟️ What’s this PR about?

ci 실패시 코멘트 남겨준다. 
더 빠르고 편하게 실패 원인을 파악한다. 

## 🔗 Related Issues / PRs

close: #23 