### PR TITLE
Lock과 관련된 경쟁 상태 해결

### DIFF
--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -28,9 +28,8 @@ pub async fn check_repository_links(
         branch: branch.clone(),
     };
 
-    let token;
     // Check if repository is already being monitored
-    {
+    let token = {
         let mut map = REPO_TASKS.lock().unwrap();
         if map.contains_key(&repo_key) {
             return Err(format!(
@@ -38,9 +37,10 @@ pub async fn check_repository_links(
                 repo_url, branch
             ));
         }
-        token = CancellationToken::new();
+        let token = CancellationToken::new();
         map.insert(repo_key.clone(), token.clone());
-    }
+        token
+    };
 
     info!(
         "Starting repository link checker for {} (branch: {})",


### PR DESCRIPTION
## ♟️ What’s this PR about?

Lock 두 번 소유할 거 한번으로 가능하게 변경하였습니다.
그리고 /cancel 이 요청됐을 때 REPO_TASKS 에서 repo_key를 두번 지우도록 구현됐었는데,(check_repository_link 에서 한번 cancel_repository_checker 에서 한번) check_repository_link 에서는 repo_key를 REPO_TASKS에서 지우지 않도록 변경하였습니다. 잠재적 버그를 개선하기 위해.

## 🔗 Related Issues / PRs

close: #34 