### PR TITLE
설정 파일(ex. base.yaml) 불러오는 방법 변경

### DIFF
--- a/rook/configuration/base.yaml
+++ b/rook/configuration/base.yaml
@@ -1,3 +1,3 @@
 email_client:
   base_url: "https://api.postmarkapp.com"
-  timeout_seconds: 10 
+  timeout_seconds: 10

--- a/rook/configuration/local.yaml
+++ b/rook/configuration/local.yaml
@@ -1,3 +1,3 @@
 email_client:
   sender_email: "noreply@redddy.com"
-  authorization_token: "test-token" 
+  authorization_token: "test-token"

--- a/rook/configuration/production.yaml
+++ b/rook/configuration/production.yaml
@@ -1,3 +1,3 @@
 email_client:
   sender_email: "${POSTMARK_SENDER_EMAIL}"
-  authorization_token: "${POSTMARK_AUTH_TOKEN}" 
+  authorization_token: "${POSTMARK_AUTH_TOKEN}"

--- a/rook/src/configuration.rs
+++ b/rook/src/configuration.rs
@@ -47,14 +47,14 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
         .try_into()
         .expect("Failed to parse APP_ENVIRONMENT");
 
-    let enviroment_config = match environment {
+    let environment_config = match environment {
         Environment::Local => LOCAL_CONFIG,
         Environment::Production => PRODUCTION_CONFIG,
     };
 
     let settings = Config::builder()
         .add_source(File::from_str(BASE_CONFIG, FileFormat::Yaml))
-        .add_source(File::from_str(enviroment_config, FileFormat::Yaml))
+        .add_source(File::from_str(environment_config, FileFormat::Yaml))
         .add_source(config::Environment::with_prefix("APP").separator("__"))
         .build()?;
 


### PR DESCRIPTION
## ♟️ What’s this PR about?

`current_dir()`를 사용해서 현재 경로를 불러오는 것이 아닌 `../configuration` 을 사용해서 설정 파일 위치를 찾도록 변경하였습니다.

## 🔗 Related Issues / PRs

close: #93 