### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shuttle_deploy.yml
+++ b/.github/workflows/shuttle_deploy.yml
@@ -1,5 +1,8 @@
 name: Shuttle Deploy
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/reddevilmidzy/queensac/security/code-scanning/1](https://github.com/reddevilmidzy/queensac/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Since the workflow does not appear to modify the repository or interact with GitHub features like issues or pull requests, the minimal permission of `contents: read` should suffice. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
