### PR TITLE
테스트할 때 통일된 테스트용 Repository로 대체

### DIFF
--- a/rook/src/git/link_extractor.rs
+++ b/rook/src/git/link_extractor.rs
@@ -92,31 +92,9 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
-    #[test]
-    #[serial]
-    fn test_extract_links_from_repo_url() -> Result<(), Box<dyn std::error::Error>> {
-        let repo_url = "https://github.com/reddevilmidzy/redddy-action";
-
-        let links = extract_links_from_repo_url(repo_url, None)?;
-
-        assert!(!links.is_empty(), "No links found in the repository");
-
-        let url_regex = Regex::new(REGEX_URL).unwrap();
-        for link in &links {
-            assert!(
-                url_regex.is_match(&link.url),
-                "Invalid URL found: {} at {}:{}",
-                link.url,
-                link.file_path,
-                link.line_number
-            );
-        }
-
-        Ok(())
-    }
+    static TEST_REPO_URL: &str = "https://github.com/reddevilmidzy/kingsac";
 
     #[test]
-    #[serial]
     fn test_find_link_in_content_duplicates() {
         let content = r#"
         https://example.com
@@ -187,10 +165,8 @@ mod tests {
     #[test]
     #[serial]
     fn test_branch_found() {
-        let repo_url = "https://github.com/reddevilmidzy/riir_os";
-        let branch = "a-freestanding-rust-binary";
-
-        let result = extract_links_from_repo_url(repo_url, Some(branch.to_string()));
+        let branch = "main";
+        let result = extract_links_from_repo_url(TEST_REPO_URL, Some(branch.to_string()));
 
         assert!(result.is_ok(), "Expected branch to be found");
     }
@@ -198,10 +174,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_branch_not_found() {
-        let repo_url = "https://github.com/reddevilmidzy/woowalog";
         let non_existent_branch = "non-existent-branch";
 
-        let result = extract_links_from_repo_url(repo_url, Some(non_existent_branch.to_string()));
+        let result =
+            extract_links_from_repo_url(TEST_REPO_URL, Some(non_existent_branch.to_string()));
 
         assert!(result.is_err(), "Expected error for non-existent branch");
         if let Err(e) = result {
@@ -210,5 +186,26 @@ mod tests {
                 "Error message should contain the branch name"
             );
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_extract_links_from_repo_url() -> Result<(), Box<dyn std::error::Error>> {
+        let result = extract_links_from_repo_url(TEST_REPO_URL, None)?;
+
+        assert!(!result.is_empty(), "No links found in the repository");
+
+        let url_regex = Regex::new(REGEX_URL).unwrap();
+        for link in &result {
+            assert!(
+                url_regex.is_match(&link.url),
+                "Invalid URL found: {} at {}:{}",
+                link.url,
+                link.file_path,
+                link.line_number
+            );
+        }
+
+        Ok(())
     }
 }

--- a/rook/src/git/repo.rs
+++ b/rook/src/git/repo.rs
@@ -80,11 +80,13 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    static TEST_REPO_URL: &str = "https://github.com/reddevilmidzy/kingsac";
+
     #[test]
     #[serial]
     fn test_checkout_branch_with_valid_branch() {
-        let repo_url = "https://github.com/reddevilmidzy/woowalog";
-        let repo_manager = RepoManager::clone_repo(repo_url, Some("main")).unwrap();
+        let repo_manager = RepoManager::clone_repo(TEST_REPO_URL, Some("main")).unwrap();
+
         assert!(repo_manager.get_repo().head().is_ok());
         assert!(repo_manager.get_repo().head().unwrap().name().unwrap() == "refs/heads/main");
     }
@@ -92,8 +94,8 @@ mod tests {
     #[test]
     #[serial]
     fn test_checkout_branch_with_default_branch() {
-        let repo_url = "https://github.com/reddevilmidzy/woowalog";
-        let repo_manager = RepoManager::clone_repo(repo_url, None).unwrap();
+        let repo_manager = RepoManager::clone_repo(TEST_REPO_URL, None).unwrap();
+
         assert!(repo_manager.get_repo().head().is_ok());
         assert!(repo_manager.get_repo().head().unwrap().name().unwrap() == "refs/heads/main");
     }
@@ -101,8 +103,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_checkout_branch_with_invalid_branch() {
-        let repo_url = "https://github.com/reddevilmidzy/woowalog";
-        let result = RepoManager::clone_repo(repo_url, Some("non-existent-branch"));
+        let result = RepoManager::clone_repo(TEST_REPO_URL, Some("non-existent-branch"));
 
         assert!(
             result.is_err(),
@@ -119,10 +120,9 @@ mod tests {
     #[test]
     #[serial]
     fn test_clone_with_not_default_branch() {
-        let repo_url = "https://github.com/reddevilmidzy/woowa-writing";
-        let repo_manager = RepoManager::clone_repo(repo_url, Some("tech")).unwrap();
+        let repo_manager = RepoManager::clone_repo(TEST_REPO_URL, Some("maout")).unwrap();
 
         assert!(repo_manager.get_repo().head().is_ok());
-        assert!(repo_manager.get_repo().head().unwrap().name().unwrap() == "refs/heads/tech");
+        assert!(repo_manager.get_repo().head().unwrap().name().unwrap() == "refs/heads/maout");
     }
 }

--- a/rook/src/git/repo.rs
+++ b/rook/src/git/repo.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, fs, path::PathBuf, time};
 
 use git2::Repository;
 use tracing::error;
@@ -60,9 +60,13 @@ impl RepoManager {
     /// A `RepoManager` instance that will automatically clean up the cloned repository when dropped.
     pub fn clone_repo(repo_url: &str, branch: Option<&str>) -> Result<Self, git2::Error> {
         let temp_dir = env::temp_dir().join(format!(
-            "github_repo_temp/{}/{}",
+            "github_repo_temp/{}/{}_{}",
             repo_url.split('/').nth(3).unwrap_or("unknown"),
-            repo_url.split('/').nth(4).unwrap_or("unknown")
+            repo_url.split('/').nth(4).unwrap_or("unknown"),
+            time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
         ));
 
         let _temp_dir_guard = TempDirGuard::new(temp_dir.clone()).map_err(|e| {

--- a/rook/src/git/repo.rs
+++ b/rook/src/git/repo.rs
@@ -1,6 +1,9 @@
 use std::{env, fs, path::PathBuf};
 
 use git2::Repository;
+use tracing::error;
+
+use crate::{GitHubUrl, file_exists_in_repo, find_last_commit_id, track_file_rename_in_commit};
 
 /// A guard that automatically removes a temporary directory when dropped.
 pub struct TempDirGuard {
@@ -32,6 +35,17 @@ pub struct RepoManager {
 }
 
 impl RepoManager {
+    /// Clones a Git repository from a GitHub URL.
+    ///
+    /// # Arguments
+    /// * `url` - The GitHub URL of the repository to clone
+    ///
+    /// # Returns
+    /// A `RepoManager` instance that will automatically clean up the cloned repository when dropped.
+    pub fn from_github_url(url: &GitHubUrl) -> Result<Self, git2::Error> {
+        Self::clone_repo(&url.clone_url(), url.branch())
+    }
+
     /// Clones a Git repository, optionally cloning only a specific branch.
     ///
     /// When a branch name is provided, only that specific branch will be cloned,
@@ -67,6 +81,52 @@ impl RepoManager {
             repo,
             _temp_dir_guard,
         })
+    }
+
+    /// Attempts to find the current location of a file in the repository
+    ///
+    /// # Returns
+    /// * `Ok(Some(String))` - The current location of the file if found
+    /// * `Ok(None)` - If the file was not found
+    /// * `Err(git2::Error)` - If there was an error accessing the repository
+    pub fn find_current_location(
+        &self,
+        github_url: &GitHubUrl,
+    ) -> Result<Option<String>, git2::Error> {
+        let file_path = github_url
+            .file_path()
+            .ok_or_else(|| git2::Error::from_str("No file path in URL"))?;
+
+        let repo = self.get_repo();
+        let mut current_path = file_path.to_string();
+
+        loop {
+            if file_exists_in_repo(repo, &current_path)? {
+                return Ok(Some(current_path));
+            }
+
+            let commit = match find_last_commit_id(&current_path, repo) {
+                Ok(commit) => commit,
+                Err(e) => {
+                    error!("Error finding last commit for {}: {}", current_path, e);
+                    return Ok(None);
+                }
+            };
+
+            match track_file_rename_in_commit(repo, &commit, &current_path)? {
+                Some(new_path) => {
+                    current_path = new_path;
+                }
+                None => {
+                    error!(
+                        "Could not find new path for {} in commit {}",
+                        current_path,
+                        commit.id()
+                    );
+                    return Ok(None);
+                }
+            }
+        }
     }
 
     /// Returns a reference to the managed Git repository.
@@ -124,5 +184,49 @@ mod tests {
 
         assert!(repo_manager.get_repo().head().is_ok());
         assert!(repo_manager.get_repo().head().unwrap().name().unwrap() == "refs/heads/maout");
+    }
+
+    #[test]
+    /// This test is related to `file_tracker::tests::test_track_file_rename_in_commit_with_multiple_moves`
+    /// which demonstrates the same file movement pattern:
+    /// 1. Initially located at: tmp.txt (root directory)
+    /// 2. First moved to: dockerfile_history/tmp.txt
+    /// 3. Finally moved to: img/tmp.txt
+    fn test_find_current_location() {
+        let url = GitHubUrl::parse(
+            "https://github.com/reddevilmidzy/zero2prod/blob/test_for_queensac/tmp.txt",
+        )
+        .unwrap();
+
+        let repo_manager = RepoManager::from_github_url(&url).unwrap();
+
+        assert_eq!(
+            repo_manager.find_current_location(&url).unwrap(),
+            Some("img/tmp.txt".to_string())
+        );
+    }
+
+    #[test]
+    /// This test verifies the behavior when a file cannot be found in the repository.
+    /// It tests two scenarios:
+    /// 1. A file that never existed in the repository
+    /// 2. A file that was deleted and not moved anywhere else
+    fn test_find_current_location_file_not_found() {
+        // Test case 1: File that never existed
+        let url =
+            GitHubUrl::parse("https://github.com/reddevilmidzy/kingsac/blob/main/non_existent.txt")
+                .unwrap();
+
+        let repo_manager = RepoManager::from_github_url(&url).unwrap();
+        assert_eq!(repo_manager.find_current_location(&url).unwrap(), None);
+
+        // Test case 2: File that was deleted
+        let url = GitHubUrl::parse(
+            "https://github.com/reddevilmidzy/kingsac/blob/main/will_be_deleted.rs",
+        )
+        .unwrap();
+
+        let repo_manager = RepoManager::from_github_url(&url).unwrap();
+        assert_eq!(repo_manager.find_current_location(&url).unwrap(), None);
     }
 }

--- a/rook/src/git/url.rs
+++ b/rook/src/git/url.rs
@@ -198,16 +198,15 @@ mod tests {
     /// 2. A file that was deleted and not moved anywhere else
     fn test_find_current_location_file_not_found() {
         // Test case 1: File that never existed
-        let url = GitHubUrl::parse(
-            "https://github.com/reddevilmidzy/test-queensac/blob/main/non_existent.txt",
-        )
-        .unwrap();
+        let url =
+            GitHubUrl::parse("https://github.com/reddevilmidzy/kingsac/blob/main/non_existent.txt")
+                .unwrap();
 
         assert_eq!(url.find_current_location().unwrap(), None);
 
         // Test case 2: File that was deleted
         let url = GitHubUrl::parse(
-            "https://github.com/reddevilmidzy/test-queensac/blob/main/will_be_deleted.rs",
+            "https://github.com/reddevilmidzy/kingsac/blob/main/will_be_deleted.rs",
         )
         .unwrap();
 

--- a/rook/src/git/url.rs
+++ b/rook/src/git/url.rs
@@ -1,7 +1,4 @@
 use regex::Regex;
-use tracing::error;
-
-use crate::{RepoManager, file_exists_in_repo, find_last_commit_id, track_file_rename_in_commit};
 
 /// Represents a parsed GitHub URL with its components
 #[derive(Debug)]
@@ -77,51 +74,6 @@ impl GitHubUrl {
     pub fn clone_url(&self) -> String {
         format!("https://github.com/{}/{}", self.owner, self.repo)
     }
-
-    /// Attempts to find the current location of a file in the repository
-    ///
-    /// # Returns
-    /// * `Ok(Some(String))` - The current location of the file if found
-    /// * `Ok(None)` - If the file was not found
-    /// * `Err(git2::Error)` - If there was an error accessing the repository
-    pub fn find_current_location(&self) -> Result<Option<String>, git2::Error> {
-        let file_path = self
-            .file_path()
-            .ok_or_else(|| git2::Error::from_str("No file path in URL"))?;
-
-        let repo_manager = RepoManager::clone_repo(&self.clone_url(), self.branch())?;
-        let repo = repo_manager.get_repo();
-
-        let mut current_path = file_path.to_string();
-
-        loop {
-            if file_exists_in_repo(repo, &current_path)? {
-                return Ok(Some(current_path));
-            }
-
-            let commit = match find_last_commit_id(&current_path, repo) {
-                Ok(commit) => commit,
-                Err(e) => {
-                    error!("Error finding last commit for {}: {}", current_path, e);
-                    return Ok(None);
-                }
-            };
-
-            match track_file_rename_in_commit(repo, &commit, &current_path)? {
-                Some(new_path) => {
-                    current_path = new_path;
-                }
-                None => {
-                    error!(
-                        "Could not find new path for {} in commit {}",
-                        current_path,
-                        commit.id()
-                    );
-                    return Ok(None);
-                }
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -171,45 +123,5 @@ mod tests {
     fn test_no_branch() {
         let url = "https://github.com/owner/repo/blob";
         assert!(GitHubUrl::parse(url).is_none());
-    }
-
-    #[test]
-    /// This test is related to `file_tracker::tests::test_track_file_rename_in_commit_with_multiple_moves`
-    /// which demonstrates the same file movement pattern:
-    /// 1. Initially located at: tmp.txt (root directory)
-    /// 2. First moved to: dockerfile_history/tmp.txt
-    /// 3. Finally moved to: img/tmp.txt
-    fn test_find_current_location() {
-        let url = GitHubUrl::parse(
-            "https://github.com/reddevilmidzy/zero2prod/blob/test_for_queensac/tmp.txt",
-        )
-        .unwrap();
-
-        assert_eq!(
-            url.find_current_location().unwrap(),
-            Some("img/tmp.txt".to_string())
-        );
-    }
-
-    #[test]
-    /// This test verifies the behavior when a file cannot be found in the repository.
-    /// It tests two scenarios:
-    /// 1. A file that never existed in the repository
-    /// 2. A file that was deleted and not moved anywhere else
-    fn test_find_current_location_file_not_found() {
-        // Test case 1: File that never existed
-        let url =
-            GitHubUrl::parse("https://github.com/reddevilmidzy/kingsac/blob/main/non_existent.txt")
-                .unwrap();
-
-        assert_eq!(url.find_current_location().unwrap(), None);
-
-        // Test case 2: File that was deleted
-        let url = GitHubUrl::parse(
-            "https://github.com/reddevilmidzy/kingsac/blob/main/will_be_deleted.rs",
-        )
-        .unwrap();
-
-        assert_eq!(url.find_current_location().unwrap(), None);
     }
 }

--- a/rook/src/link_checker/link.rs
+++ b/rook/src/link_checker/link.rs
@@ -78,21 +78,21 @@ mod tests {
 
     #[tokio::test]
     async fn change_branch_name() {
-        let link = "https://github.com/sindresorhus/cli-spinners/tree/master";
+        let link = "https://github.com/reddevilmidzy/kingsac/tree/forever";
         assert_eq!(
             check_link(link).await,
             LinkCheckResult::Redirect(
-                "https://github.com/sindresorhus/cli-spinners/tree/main".to_string()
+                "https://github.com/reddevilmidzy/kingsac/tree/lie".to_string()
             )
         );
     }
 
     #[tokio::test]
     async fn change_repository_name() {
-        let link = "https://github.com/reddevilmidzy/coduo-java-rps";
+        let link = "https://github.com/reddevilmidzy/test-queensac";
         assert_eq!(
             check_link(link).await,
-            LinkCheckResult::Redirect("https://github.com/reddevilmidzy/coduo-rps".to_string())
+            LinkCheckResult::Redirect("https://github.com/reddevilmidzy/kingsac".to_string())
         );
     }
 }

--- a/rook/src/link_checker/link.rs
+++ b/rook/src/link_checker/link.rs
@@ -1,4 +1,4 @@
-use crate::GitHubUrl;
+use crate::{GitHubUrl, RepoManager};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum LinkCheckResult {
@@ -31,7 +31,10 @@ pub async fn check_link(url: &str) -> LinkCheckResult {
                     return LinkCheckResult::Valid;
                 } else if status.as_u16() == 404 && url.contains("github.com") {
                     if let Some(parsed) = GitHubUrl::parse(url) {
-                        if let Ok(Some(new_path)) = parsed.find_current_location() {
+                        if let Ok(Some(new_path)) = RepoManager::from_github_url(&parsed)
+                            .unwrap()
+                            .find_current_location(&parsed)
+                        {
                             return LinkCheckResult::GitHubFileMoved(new_path);
                         }
                     }

--- a/rook/tests/api/helpers.rs
+++ b/rook/tests/api/helpers.rs
@@ -68,5 +68,5 @@ pub fn create_test_subscriber() -> NewSubscriber {
 
 /// generate a test repo url
 pub fn create_test_repo_url() -> RepositoryURL {
-    RepositoryURL::new("https://github.com/reddevilmidzy/woowalog").unwrap()
+    RepositoryURL::new("https://github.com/reddevilmidzy/kingsac").unwrap()
 }


### PR DESCRIPTION
## ♟️ What’s this PR about?

* GItHub sturct에 있던 파일 트래킹 함수(find_current_location)를 RepoManager struct로 이동
  * GitHub struct에는 정규표현식을 사용한 url 추출기능만 있도록 수정하였고, RepoManager에는 clone, find commit 등 repository와 관련된 역할을 갖게 수정하였다.
* clone할 파일 이름에 타임스탬프를 추가하여 같은 repository를 클론할 수 있게 하였다.
  * 기존에는 생성할 파일 이름 때문에 충돌이 발생했었음

이슈 #105 의 목적은 mod tests { } 안에 REPO_MANAGER 하나 처음에 딱 클론 한다음 각 테스트가 이 REPO_MANAGER를 공유해서 사용하길 바랬는데, 구현하다보니까 계속 예상치 못한 문제가 발생했다. 그래서 그냥 각각의 테스트마다 clone하되 추후 병렬 테스트로 속도를 향상시켜보도록 하자. 


## 🔗 Related Issues / PRs

close: #105 
