### PR TITLE
`redddy.com` 에서 `queens.ac`로 도메인 변경

### DIFF
--- a/rook/configuration/local.yaml
+++ b/rook/configuration/local.yaml
@@ -1,3 +1,9 @@
 email_client:
   sender_email: "noreply@redddy.com"
   authorization_token: "test-token"
+
+cors:
+  allowed_origins:
+    - "http://localhost:3000"
+    - "https://queens.ac"
+    - "https://www.queens.ac"

--- a/rook/configuration/production.yaml
+++ b/rook/configuration/production.yaml
@@ -1,3 +1,8 @@
 email_client:
   sender_email: "${POSTMARK_SENDER_EMAIL}"
   authorization_token: "${POSTMARK_AUTH_TOKEN}"
+
+cors:
+  allowed_origins:
+    - "https://queens.ac"
+    - "https://www.queens.ac"

--- a/rook/src/configuration.rs
+++ b/rook/src/configuration.rs
@@ -11,6 +11,7 @@ const PRODUCTION_CONFIG: &str = include_str!("../configuration/production.yaml")
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub email_client: EmailClientSettings,
+    pub cors: CorsSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -20,6 +21,11 @@ pub struct EmailClientSettings {
     #[serde(deserialize_with = "deserialize_secret")]
     pub authorization_token: Secret<String>,
     pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CorsSettings {
+    pub allowed_origins: Vec<String>,
 }
 
 fn deserialize_secret<'de, D>(deserializer: D) -> Result<Secret<String>, D::Error>


### PR DESCRIPTION
## ♟️ What’s this PR about?

`redddy.com` 에서 `queens.ac`로 도메인 변경하였습니다.

![image](https://github.com/user-attachments/assets/9e7b0f10-d977-42b5-a815-e34d50276baa)

45달러 플렉스...ㅎ

close: #112 