### PR TITLE
 이슈, PR 생성시 자동으로 마일스톤 할당

### DIFF
--- a/.github/workflows/milestone_assign.yml
+++ b/.github/workflows/milestone_assign.yml
@@ -1,0 +1,43 @@
+name: Auto Assign Milestone
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assign current milestone
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const milestones = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'due_on',
+              direction: 'asc'
+            });
+            
+            if (milestones.data.length > 0) {
+              const currentMilestone = milestones.data[0];
+              
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  milestone: currentMilestone.number
+                });
+              } catch (error) {
+                console.error('Failed to update issue with milestone:', error);
+              }
+            }


### PR DESCRIPTION
## ♟️ What’s this PR about?

깃허브 액션을 사용하여 이슈, PR 생성시 자동으로 마일스톤 할당할 수 있도록 스크립트를 작성하였습니다.

깃허브 마켓플레이스 가니까 관련 스크립트와 액션 러너가 있었지만, 크게 중요한 기능이 아니고 또 직접 구현하는 것도 번거롭지 않기에 직접 구현하였습니다. 

## 🔗 Related Issues / PRs

close: #119 