### PR TITLE
이메일로 결과 전송 기능 구현

### DIFF
--- a/rook/src/domain/email_verification_service.rs
+++ b/rook/src/domain/email_verification_service.rs
@@ -2,6 +2,7 @@ use crate::domain::{SubscriberEmail, email_verification::EmailVerificationStore}
 use crate::email_client::EmailClient;
 use secrecy::ExposeSecret;
 use sqlx::PgPool;
+use std::time::Duration;
 
 pub struct EmailVerificationService {
     store: EmailVerificationStore,
@@ -38,11 +39,13 @@ impl EmailVerificationService {
         );
 
         self.email_client
-            .send_email(
+            .send_email_with_retry(
                 subscriber_email,
                 subject.to_string(),
                 html_content,
                 "broadcast".to_string(),
+                3,
+                Duration::from_secs(60),
             )
             .await
     }

--- a/rook/src/email_client.rs
+++ b/rook/src/email_client.rs
@@ -69,6 +69,44 @@ impl EmailClient {
             }
         }
     }
+
+    pub async fn send_email_with_retry(
+        &self,
+        recipient: SubscriberEmail,
+        subject: String,
+        html_content: String,
+        message_stream: String,
+        max_retries: usize,
+        retry_delay: Duration,
+    ) -> Result<(), String> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match self
+                .send_email(
+                    recipient.clone(),
+                    subject.clone(),
+                    html_content.clone(),
+                    message_stream.clone(),
+                )
+                .await
+            {
+                Ok(_) => {
+                    return Ok(());
+                }
+                Err(e) => {
+                    if attempt >= max_retries {
+                        return Err(format!(
+                            "Failed to send email after {} attempts. Last error: {}",
+                            attempt, e
+                        ));
+                    } else {
+                        tokio::time::sleep(retry_delay).await;
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -164,5 +202,108 @@ mod tests {
 
         // Assert
         assert!(outcome.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_email_with_retry_succeeds_on_first_try() {
+        let mock_server = wiremock::MockServer::start().await;
+        let sender = SubscriberEmail::new("sender@example.com").unwrap();
+        let recipient = SubscriberEmail::new("recipient@example.com").unwrap();
+        let email_client = EmailClient::new(
+            mock_server.uri(),
+            sender,
+            Secret::new("test-token".to_string()),
+            Duration::from_secs(10),
+        );
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let result = email_client
+            .send_email_with_retry(
+                recipient,
+                "subject".to_string(),
+                "<p>content</p>".to_string(),
+                "broadcast".to_string(),
+                3,
+                Duration::from_millis(10),
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_email_with_retry_succeeds_after_retries() {
+        let mock_server = wiremock::MockServer::start().await;
+        let sender = SubscriberEmail::new("sender@example.com").unwrap();
+        let recipient = SubscriberEmail::new("recipient@example.com").unwrap();
+        let email_client = EmailClient::new(
+            mock_server.uri(),
+            sender,
+            Secret::new("test-token".to_string()),
+            Duration::from_secs(10),
+        );
+
+        // 처음 두 번은 실패, 세 번째는 성공
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .up_to_n_times(2)
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let result = email_client
+            .send_email_with_retry(
+                recipient,
+                "subject".to_string(),
+                "<p>content</p>".to_string(),
+                "broadcast".to_string(),
+                3,
+                Duration::from_millis(10),
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_email_with_retry_fails_after_all_retries() {
+        let mock_server = wiremock::MockServer::start().await;
+        let sender = SubscriberEmail::new("sender@example.com").unwrap();
+        let recipient = SubscriberEmail::new("recipient@example.com").unwrap();
+        let email_client = EmailClient::new(
+            mock_server.uri(),
+            sender,
+            Secret::new("test-token".to_string()),
+            Duration::from_secs(10),
+        );
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .expect(3)
+            .mount(&mock_server)
+            .await;
+
+        let result = email_client
+            .send_email_with_retry(
+                recipient,
+                "subject".to_string(),
+                "<p>content</p>".to_string(),
+                "broadcast".to_string(),
+                3,
+                Duration::from_millis(10),
+            )
+            .await;
+
+        assert!(result.is_err());
     }
 }

--- a/rook/src/link_checker/scheduler.rs
+++ b/rook/src/link_checker/scheduler.rs
@@ -225,11 +225,13 @@ pub async fn check_repository_links(
 
                         // Send email report
                         let (subject, html_content) = summary.generate_email_content(repo_url, branch.as_deref());
-                        if let Err(e) = email_client.send_email(
+                        if let Err(e) = email_client.send_email_with_retry(
                             subscriber_email.clone(),
                             subject,
                             html_content,
                             "broadcast".to_string(),
+                            3,
+                            Duration::from_secs(60),
                         ).await {
                             error!("Failed to send email report: {}", e);
                         } else {

--- a/rook/src/main.rs
+++ b/rook/src/main.rs
@@ -72,11 +72,13 @@ async fn check_handler(
         return Err(StatusCode::BAD_REQUEST);
     }
     email_client
-        .send_email(
+        .send_email_with_retry(
             payload.subscriber.email().clone(),
             "Repository checker started".to_string(),
             "<p>Repository checker started</p>".to_string(),
             "broadcast".to_string(),
+            3,
+            Duration::from_secs(60),
         )
         .await
         .map_err(|e| {
@@ -100,11 +102,13 @@ async fn cancel_handler(
         return Err(StatusCode::BAD_REQUEST);
     }
     email_client
-        .send_email(
+        .send_email_with_retry(
             payload.subscriber.email().clone(),
             "Repository checker cancelled".to_string(),
             "<p>Repository checker cancelled</p>".to_string(),
             "broadcast".to_string(),
+            3,
+            Duration::from_secs(60),
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
## ♟️ What’s this PR about?

링크 체크를 위한 이메일이 등록되면 아래 이미지와 같이 처음 메일이 전송되고,

![Image](https://github.com/user-attachments/assets/015e0669-43e2-4753-81d4-fde20508a27a)


매 주기마다 아래와 같이 체크 결과에 대해 메일이 전송된다.

![Image](https://github.com/user-attachments/assets/daa7753b-ca2d-43d8-a51c-aa743f42ba14)


고민이 되는 부분은 현재 `link_check/scheduler.rs`에 이런 이메일 형태 전송 형태로 변경하는 로직이 포함되어 있는데, 이 로직이 해당 파일에 있는게 적절한 지 고민이 된다. 
`link_check/sse.rs` 에서도 카운터 증가하는 로직과 sse로 전송하는 로직이 `sse.rs` 한 파일안에 있어서, 이번에도 비슷하게 구현하였는데, 적절한 위치(어울리고 유지보수하기 편한)를 찾게 된다면 그 곳으로 옮기도록 하자.

## 🔗 Related Issues / PRs

close: #123
