### PR TITLE
파일 변경 후 Pull Request 생성 구현

### DIFF
--- a/rook/.sqlx/query-bdbac467ae90075b836db2aec5729c159c1e96d4cf691b0f6b4b51b2361cf710.json
+++ b/rook/.sqlx/query-bdbac467ae90075b836db2aec5729c159c1e96d4cf691b0f6b4b51b2361cf710.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM repo WHERE repo_url = $1 AND branch = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "bdbac467ae90075b836db2aec5729c159c1e96d4cf691b0f6b4b51b2361cf710"
+}

--- a/rook/.sqlx/query-cc44dadc799019ce0c67bf4ebf1b47f2a0e6ec4ce623e768afe1c25db025cabd.json
+++ b/rook/.sqlx/query-cc44dadc799019ce0c67bf4ebf1b47f2a0e6ec4ce623e768afe1c25db025cabd.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT file_path, old_content, new_content, line_number FROM check_result WHERE repo_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "file_path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "old_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "new_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_number",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "cc44dadc799019ce0c67bf4ebf1b47f2a0e6ec4ce623e768afe1c25db025cabd"
+}

--- a/rook/Cargo.lock
+++ b/rook/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "shuttle-runtime",
  "shuttle-shared-db",
  "sqlx",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tower-http",

--- a/rook/Cargo.lock
+++ b/rook/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
  "shuttle-runtime",
  "shuttle-shared-db",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower-http",

--- a/rook/Cargo.toml
+++ b/rook/Cargo.toml
@@ -34,7 +34,7 @@ dotenvy = "0.15"
 chrono = { version = "0.4.41", features = ["serde"] }
 rand = { version = "0.9", features = ["std_rng"] }
 config = "0.15"
-thiserror = "1.0" # 2로 올려보기
+thiserror = "2.0"
 
 [dev-dependencies]
 serial_test = "3.0.0"

--- a/rook/Cargo.toml
+++ b/rook/Cargo.toml
@@ -34,6 +34,7 @@ dotenvy = "0.15"
 chrono = { version = "0.4.41", features = ["serde"] }
 rand = { version = "0.9", features = ["std_rng"] }
 config = "0.15"
+thiserror = "1.0" # 2로 올려보기
 
 [dev-dependencies]
 serial_test = "3.0.0"

--- a/rook/migrations/20250707131919_create_check_result_table.sql
+++ b/rook/migrations/20250707131919_create_check_result_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE repo (
+    id SERIAL PRIMARY KEY,
+    repo_url TEXT NOT NULL,
+    branch TEXT,
+    checked_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE check_result (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
+    file_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    old_content TEXT NOT NULL,
+    new_content TEXT NOT NULL
+);

--- a/rook/src/git/mod.rs
+++ b/rook/src/git/mod.rs
@@ -1,9 +1,11 @@
 mod file_tracker;
 mod link_extractor;
+mod pr_generator;
 mod repo;
 mod url;
 
 pub use file_tracker::*;
 pub use link_extractor::*;
+pub use pr_generator::*;
 pub use repo::*;
 pub use url::*;

--- a/rook/src/git/pr_generator.rs
+++ b/rook/src/git/pr_generator.rs
@@ -1,6 +1,7 @@
 use crate::RepoManager;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{error, info};
@@ -19,22 +20,16 @@ pub enum PrError {
     Json(#[from] serde_json::Error),
     #[error("Configuration error: {0}")]
     Config(String),
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, sqlx::FromRow)]
 pub struct FileChange {
     pub file_path: String,
     pub old_content: String,
     pub new_content: String,
-    pub line_number: u32,
-}
-
-#[derive(Debug)]
-pub struct LinkFix {
-    pub file_path: String,
-    pub line_number: u32,
-    pub old_url: String,
-    pub new_url: String,
+    pub line_number: i32,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,8 +77,53 @@ impl PullRequestGenerator {
         }
     }
 
+    pub async fn find_repo_id(
+        &self,
+        pool: &PgPool,
+        repo_url: &str,
+        branch: Option<&str>,
+    ) -> Result<i32, PrError> {
+        let repo_id = sqlx::query!(
+            "SELECT id FROM repo WHERE repo_url = $1 AND branch = $2",
+            repo_url,
+            branch
+        )
+        .fetch_one(pool)
+        .await?;
+
+        Ok(repo_id.id)
+    }
+
+    pub async fn find_file_changes(
+        &self,
+        pool: &PgPool,
+        repo_id: i32,
+    ) -> Result<Vec<FileChange>, PrError> {
+        let result = sqlx::query_as!(
+            FileChange,
+            "SELECT file_path, old_content, new_content, line_number FROM check_result WHERE repo_id = $1",
+            repo_id
+        ).fetch_all(pool)
+        .await?;
+
+        Ok(result)
+    }
+
+    pub async fn find_check_result(
+        &self,
+        pool: &PgPool,
+        repo_url: &str,
+        branch: Option<&str>,
+    ) -> Result<String, PrError> {
+        let repo_id = self.find_repo_id(pool, repo_url, branch).await?;
+        let file_changes = self.find_file_changes(pool, repo_id).await?;
+
+        let pr_url = self.create_fix_pr(file_changes).await?;
+        Ok(pr_url)
+    }
+
     /// Creates a pull request with link fixes
-    pub async fn create_fix_pr(&self, fixes: Vec<LinkFix>) -> Result<String, PrError> {
+    pub async fn create_fix_pr(&self, fixes: Vec<FileChange>) -> Result<String, PrError> {
         self.create_feature_branch().await?;
 
         let changes = self.apply_fixes(fixes).await?;
@@ -114,7 +154,7 @@ impl PullRequestGenerator {
     }
 
     /// Applies link fixes to files
-    async fn apply_fixes(&self, fixes: Vec<LinkFix>) -> Result<Vec<FileChange>, PrError> {
+    async fn apply_fixes(&self, fixes: Vec<FileChange>) -> Result<Vec<FileChange>, PrError> {
         let mut changes = Vec::new();
 
         for fix in fixes {
@@ -133,8 +173,8 @@ impl PullRequestGenerator {
             let new_content = self.replace_line_content(
                 &current_content,
                 fix.line_number as usize,
-                &fix.old_url,
-                &fix.new_url,
+                &fix.old_content,
+                &fix.new_content,
             )?;
 
             tokio::fs::write(&full_path, &new_content)
@@ -531,11 +571,11 @@ mod tests {
             .await;
 
         // Create test fixes
-        let fixes = vec![LinkFix {
+        let fixes = vec![FileChange {
             file_path: "test.md".to_string(),
             line_number: 3,
-            old_url: "https://broken-url.com".to_string(),
-            new_url: "https://working-url.com".to_string(),
+            old_content: "https://broken-url.com".to_string(),
+            new_content: "https://working-url.com".to_string(),
         }];
 
         let result = generator.create_fix_pr(fixes).await;

--- a/rook/src/git/pr_generator.rs
+++ b/rook/src/git/pr_generator.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{error, info};
 
+/// Represents errors that can occur during pull request generation.
 #[derive(Debug, Error)]
 pub enum PrError {
     #[error("Git operation failed: {0}")]
@@ -25,6 +26,7 @@ pub enum PrError {
 }
 
 #[derive(Debug, sqlx::FromRow)]
+/// Represents a file change to be included in a pull request.
 pub struct FileChange {
     pub file_path: String,
     pub old_content: String,
@@ -33,6 +35,7 @@ pub struct FileChange {
 }
 
 #[derive(Debug, Serialize)]
+/// Structure for creating a GitHub pull request via API.
 struct GitHubPullRequest {
     title: String,
     body: String,
@@ -41,11 +44,13 @@ struct GitHubPullRequest {
 }
 
 #[derive(Debug, Deserialize)]
+/// Structure for parsing the response from GitHub pull request API.
 struct GitHubPullRequestResponse {
     html_url: String,
     number: u32,
 }
 
+/// Generates pull requests for link fixes in a repository.
 pub struct PullRequestGenerator {
     repo_manager: RepoManager,
     github_token: String,
@@ -57,6 +62,16 @@ pub struct PullRequestGenerator {
 }
 
 impl PullRequestGenerator {
+    /// Creates a new PullRequestGenerator.
+    ///
+    /// # Arguments
+    /// * `repo_manager` - The repository manager instance
+    /// * `github_token` - GitHub API token
+    /// * `base_branch` - The base branch for the pull request
+    /// * `feature_branch` - The feature branch to create
+    /// * `author_name` - The commit author name
+    /// * `author_email` - The commit author email
+    /// * `http_client` - The HTTP client for API requests
     pub fn new(
         repo_manager: RepoManager,
         github_token: String,
@@ -77,6 +92,12 @@ impl PullRequestGenerator {
         }
     }
 
+    /// Finds the repository ID in the database for a given URL and branch.
+    ///
+    /// # Arguments
+    /// * `pool` - The database connection pool
+    /// * `repo_url` - The repository URL
+    /// * `branch` - The branch name (optional)
     pub async fn find_repo_id(
         &self,
         pool: &PgPool,
@@ -94,6 +115,11 @@ impl PullRequestGenerator {
         Ok(repo_id.id)
     }
 
+    /// Finds file changes for a given repository ID.
+    ///
+    /// # Arguments
+    /// * `pool` - The database connection pool
+    /// * `repo_id` - The repository ID
     pub async fn find_file_changes(
         &self,
         pool: &PgPool,
@@ -109,6 +135,12 @@ impl PullRequestGenerator {
         Ok(result)
     }
 
+    /// Finds the check result and creates a fix pull request.
+    ///
+    /// # Arguments
+    /// * `pool` - The database connection pool
+    /// * `repo_url` - The repository URL
+    /// * `branch` - The branch name (optional)
     pub async fn find_check_result(
         &self,
         pool: &PgPool,
@@ -122,7 +154,10 @@ impl PullRequestGenerator {
         Ok(pr_url)
     }
 
-    /// Creates a pull request with link fixes
+    /// Creates a pull request with link fixes.
+    ///
+    /// # Arguments
+    /// * `fixes` - The list of file changes to apply
     pub async fn create_fix_pr(&self, fixes: Vec<FileChange>) -> Result<String, PrError> {
         self.create_feature_branch().await?;
 
@@ -137,7 +172,7 @@ impl PullRequestGenerator {
         Ok(pr_url)
     }
 
-    /// Creates a new feature branch from the current branch
+    /// Creates a new feature branch from the current branch.
     async fn create_feature_branch(&self) -> Result<(), PrError> {
         self.repo_manager
             .create_branch(&self.feature_branch)
@@ -153,7 +188,10 @@ impl PullRequestGenerator {
         Ok(())
     }
 
-    /// Applies link fixes to files
+    /// Applies link fixes to files in the repository.
+    ///
+    /// # Arguments
+    /// * `fixes` - The list of file changes to apply
     async fn apply_fixes(&self, fixes: Vec<FileChange>) -> Result<Vec<FileChange>, PrError> {
         let mut changes = Vec::new();
 
@@ -200,7 +238,13 @@ impl PullRequestGenerator {
         Ok(changes)
     }
 
-    /// Replaces content in a specific line
+    /// Replaces content in a specific line of a file.
+    ///
+    /// # Arguments
+    /// * `content` - The file content
+    /// * `line_number` - The line number to replace (1-based)
+    /// * `old_url` - The old URL to replace
+    /// * `new_url` - The new URL to insert
     fn replace_line_content(
         &self,
         content: &str,
@@ -234,7 +278,10 @@ impl PullRequestGenerator {
         Ok(new_lines.join("\n"))
     }
 
-    /// Commits all changes
+    /// Commits all file changes to the repository.
+    ///
+    /// # Arguments
+    /// * `changes` - The list of file changes to commit
     async fn commit_changes(&self, changes: &[FileChange]) -> Result<(), PrError> {
         info!("Committing {} file changes", changes.len());
 
@@ -252,7 +299,10 @@ impl PullRequestGenerator {
         Ok(())
     }
 
-    /// Creates a descriptive commit message
+    /// Creates a descriptive commit message for the changes.
+    ///
+    /// # Arguments
+    /// * `changes` - The list of file changes
     fn create_commit_message(&self, changes: &[FileChange]) -> String {
         let mut message = String::from("fix: Update broken links\n\n");
 
@@ -269,7 +319,7 @@ impl PullRequestGenerator {
         message
     }
 
-    /// Pushes the feature branch to the remote repository
+    /// Pushes the feature branch to the remote repository.
     async fn push_to_remote(&self) -> Result<(), PrError> {
         info!("Pushing branch {} to remote", self.feature_branch);
 
@@ -281,7 +331,7 @@ impl PullRequestGenerator {
         Ok(())
     }
 
-    /// Creates a pull request via GitHub API
+    /// Creates a pull request via the GitHub API.
     pub async fn create_pull_request_via_api(&self) -> Result<String, PrError> {
         info!("Creating pull request via GitHub API");
 
@@ -321,7 +371,7 @@ impl PullRequestGenerator {
         Ok(pr_response.html_url)
     }
 
-    /// Gets the GitHub API URL for the repository
+    /// Gets the GitHub API URL for the repository.
     fn get_repo_url(&self) -> Result<String, PrError> {
         let repo_path = self.repo_manager.get_repo_path();
 
@@ -336,7 +386,7 @@ impl PullRequestGenerator {
         Ok(format!("https://api.github.com/repos/{}/{}", owner, repo))
     }
 
-    /// Creates a description for the pull request
+    /// Creates a description for the pull request.
     fn create_pr_description(&self) -> String {
         "## 🔗 Link Fixes
 

--- a/rook/src/git/pr_generator.rs
+++ b/rook/src/git/pr_generator.rs
@@ -1,0 +1,556 @@
+use crate::RepoManager;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+use tracing::{error, info};
+
+#[derive(Debug, Error)]
+pub enum PrError {
+    #[error("Git operation failed: {0}")]
+    Git(#[from] git2::Error),
+    #[error("GitHub API error: {0}")]
+    GitHub(String),
+    #[error("File operation failed: {0}")]
+    File(String),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("JSON serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+#[derive(Debug)]
+pub struct FileChange {
+    pub file_path: String,
+    pub old_content: String,
+    pub new_content: String,
+    pub line_number: u32,
+}
+
+#[derive(Debug)]
+pub struct LinkFix {
+    pub file_path: String,
+    pub line_number: u32,
+    pub old_url: String,
+    pub new_url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GitHubPullRequest {
+    title: String,
+    body: String,
+    head: String,
+    base: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubPullRequestResponse {
+    html_url: String,
+    number: u32,
+}
+
+pub struct PullRequestGenerator {
+    repo_manager: RepoManager,
+    github_token: String,
+    base_branch: String,
+    feature_branch: String,
+    author_name: String,
+    author_email: String,
+    http_client: Client,
+}
+
+impl PullRequestGenerator {
+    pub fn new(
+        repo_manager: RepoManager,
+        github_token: String,
+        base_branch: String,
+        feature_branch: String,
+        author_name: String,
+        author_email: String,
+        http_client: Client,
+    ) -> Self {
+        Self {
+            repo_manager,
+            github_token,
+            base_branch,
+            feature_branch,
+            author_name,
+            author_email,
+            http_client,
+        }
+    }
+
+    /// Creates a pull request with link fixes
+    pub async fn create_fix_pr(&self, fixes: Vec<LinkFix>) -> Result<String, PrError> {
+        self.create_feature_branch().await?;
+
+        let changes = self.apply_fixes(fixes).await?;
+
+        self.commit_changes(&changes).await?;
+        self.push_to_remote().await?;
+
+        let pr_url = self.create_pull_request_via_api().await?;
+
+        info!("Successfully created PR: {}", pr_url);
+        Ok(pr_url)
+    }
+
+    /// Creates a new feature branch from the current branch
+    async fn create_feature_branch(&self) -> Result<(), PrError> {
+        self.repo_manager
+            .create_branch(&self.feature_branch)
+            .await?;
+        self.repo_manager
+            .checkout_branch(&self.feature_branch)
+            .await?;
+
+        info!(
+            "Successfully created and checked out branch: {}",
+            self.feature_branch
+        );
+        Ok(())
+    }
+
+    /// Applies link fixes to files
+    async fn apply_fixes(&self, fixes: Vec<LinkFix>) -> Result<Vec<FileChange>, PrError> {
+        let mut changes = Vec::new();
+
+        for fix in fixes {
+            let file_path = PathBuf::from(&fix.file_path);
+            let full_path = self.repo_manager.get_repo_path().join(&file_path);
+
+            if !full_path.exists() {
+                error!("File not found: {}", fix.file_path);
+                continue;
+            }
+
+            let current_content = tokio::fs::read_to_string(&full_path).await.map_err(|e| {
+                PrError::File(format!("Failed to read file {}: {}", fix.file_path, e))
+            })?;
+
+            let new_content = self.replace_line_content(
+                &current_content,
+                fix.line_number as usize,
+                &fix.old_url,
+                &fix.new_url,
+            )?;
+
+            tokio::fs::write(&full_path, &new_content)
+                .await
+                .map_err(|e| {
+                    PrError::File(format!("Failed to write file {}: {}", fix.file_path, e))
+                })?;
+
+            changes.push(FileChange {
+                file_path: fix.file_path.clone(),
+                old_content: current_content,
+                new_content,
+                line_number: fix.line_number,
+            });
+
+            info!(
+                "Applied fix to {}:{}",
+                fix.file_path.clone(),
+                fix.line_number
+            );
+        }
+
+        Ok(changes)
+    }
+
+    /// Replaces content in a specific line
+    fn replace_line_content(
+        &self,
+        content: &str,
+        line_number: usize,
+        old_url: &str,
+        new_url: &str,
+    ) -> Result<String, PrError> {
+        let lines: Vec<&str> = content.lines().collect();
+
+        if line_number == 0 || line_number > lines.len() {
+            return Err(PrError::File(format!(
+                "Invalid line number: {}",
+                line_number
+            )));
+        }
+
+        let line_index = line_number - 1;
+        let old_line = lines[line_index];
+
+        if !old_line.contains(old_url) {
+            return Err(PrError::File(format!(
+                "Old URL '{}' not found in line {}: {}",
+                old_url, line_number, old_line
+            )));
+        }
+
+        let new_line = old_line.replace(old_url, new_url);
+        let mut new_lines = lines.clone();
+        new_lines[line_index] = &new_line;
+
+        Ok(new_lines.join("\n"))
+    }
+
+    /// Commits all changes
+    async fn commit_changes(&self, changes: &[FileChange]) -> Result<(), PrError> {
+        info!("Committing {} file changes", changes.len());
+
+        for change in changes {
+            self.repo_manager.add_file(&change.file_path).await?;
+        }
+
+        let commit_message = self.create_commit_message(changes);
+
+        self.repo_manager
+            .commit(&commit_message, &self.author_name, &self.author_email)
+            .await?;
+
+        info!("Successfully committed changes");
+        Ok(())
+    }
+
+    /// Creates a descriptive commit message
+    fn create_commit_message(&self, changes: &[FileChange]) -> String {
+        let mut message = String::from("fix: Update broken links\n\n");
+
+        for change in changes {
+            message.push_str(&format!(
+                "- Update link in {}:{}\n",
+                change.file_path, change.line_number
+            ));
+        }
+
+        message.push_str(
+            "\nThis PR was automatically generated to fix broken links in the repository.",
+        );
+        message
+    }
+
+    /// Pushes the feature branch to the remote repository
+    async fn push_to_remote(&self) -> Result<(), PrError> {
+        info!("Pushing branch {} to remote", self.feature_branch);
+
+        self.repo_manager
+            .push("origin", &self.feature_branch)
+            .await?;
+
+        info!("Successfully pushed branch to remote");
+        Ok(())
+    }
+
+    /// Creates a pull request via GitHub API
+    pub async fn create_pull_request_via_api(&self) -> Result<String, PrError> {
+        info!("Creating pull request via GitHub API");
+
+        let repo_url = self.get_repo_url()?;
+        let api_url = format!("{}/pulls", repo_url);
+
+        let pr_data = GitHubPullRequest {
+            title: "fix: Update broken links".to_string(),
+            body: self.create_pr_description(),
+            head: self.feature_branch.clone(),
+            base: self.base_branch.clone(),
+        };
+
+        let response = self
+            .http_client
+            .post(&api_url)
+            .header("Authorization", format!("token {}", self.github_token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "queensac")
+            .json(&pr_data)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if !status.is_success() {
+            let error_text = response.text().await?;
+            return Err(PrError::GitHub(format!(
+                "Failed to create PR: {} - {}",
+                status, error_text
+            )));
+        }
+
+        let pr_response: GitHubPullRequestResponse = response.json().await?;
+
+        info!("Successfully created PR #{}", pr_response.number);
+        Ok(pr_response.html_url)
+    }
+
+    /// Gets the GitHub API URL for the repository
+    fn get_repo_url(&self) -> Result<String, PrError> {
+        let repo_path = self.repo_manager.get_repo_path();
+
+        let path_components: Vec<&str> = repo_path.to_str().unwrap().split('/').collect();
+        if path_components.len() < 2 {
+            return Err(PrError::Config("Invalid repository path".to_string()));
+        }
+
+        let owner = path_components[path_components.len() - 2];
+        let repo = path_components[path_components.len() - 1];
+
+        Ok(format!("https://api.github.com/repos/{}/{}", owner, repo))
+    }
+
+    /// Creates a description for the pull request
+    fn create_pr_description(&self) -> String {
+        "## 🔗 Link Fixes
+
+This pull request was automatically generated to fix broken links in the repository.
+
+### What was changed?
+- Updated broken links to their correct destinations
+- All changes were automatically detected and fixed
+
+### How to review?
+1. Check that the new links are correct and accessible
+2. Verify that the changes don't break any existing functionality
+3. Ensure the commit messages are descriptive
+
+---
+*This PR was generated by the queens.ac*"
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TempDirGuard;
+    use std::env;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    async fn create_test_pr_generator() -> PullRequestGenerator {
+        let (_temp_guard, repo_manager) = create_test_repo().await;
+        PullRequestGenerator::new(
+            repo_manager,
+            "test_token".to_string(),
+            "main".to_string(),
+            "fix-links".to_string(),
+            "Test User".to_string(),
+            "test@example.com".to_string(),
+            Client::new(),
+        )
+    }
+
+    async fn create_test_repo() -> (TempDirGuard, RepoManager) {
+        let temp_dir = env::temp_dir().join(format!(
+            "test_repo_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let temp_dir_guard = TempDirGuard::new(temp_dir.clone()).unwrap();
+        let repo_path = temp_dir_guard.get_path();
+
+        // Initialize a git repository
+        let repo = git2::Repository::init(repo_path).unwrap();
+
+        // Create a test file
+        let test_file = repo_path.join("test.md");
+        tokio::fs::write(
+            &test_file,
+            "# Test\n\nThis is a [broken link](https://broken-url.com)\n",
+        )
+        .await
+        .unwrap();
+
+        // Add and commit the file
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("test.md")).unwrap();
+        index.write().unwrap();
+
+        let signature = git2::Signature::now("Test User", "test@example.com").unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+
+        repo.commit(
+            Some("refs/heads/main"),
+            &signature,
+            &signature,
+            "Initial commit",
+            &tree,
+            &[],
+        )
+        .unwrap();
+
+        let repo_manager =
+            RepoManager::clone_repo(&repo_path.to_str().unwrap(), Some("main")).unwrap();
+
+        (temp_dir_guard, repo_manager)
+    }
+
+    #[tokio::test]
+    async fn test_replace_line_content() {
+        let generator = create_test_pr_generator();
+
+        let content = "Line 1\nLine 2 with https://old-url.com\nLine 3";
+        let new_content = generator
+            .await
+            .replace_line_content(content, 2, "https://old-url.com", "https://new-url.com")
+            .unwrap();
+
+        assert!(new_content.contains("https://new-url.com"));
+        assert!(!new_content.contains("https://old-url.com"));
+    }
+
+    #[tokio::test]
+    async fn test_create_commit_message() {
+        let generator = create_test_pr_generator();
+
+        let changes = vec![
+            FileChange {
+                file_path: "test.md".to_string(),
+                old_content: "old".to_string(),
+                new_content: "new".to_string(),
+                line_number: 3,
+            },
+            FileChange {
+                file_path: "readme.md".to_string(),
+                old_content: "old".to_string(),
+                new_content: "new".to_string(),
+                line_number: 10,
+            },
+        ];
+
+        let message = generator.await.create_commit_message(&changes);
+
+        assert!(message.contains("fix: Update broken links"));
+        assert!(message.contains("test.md:3"));
+        assert!(message.contains("readme.md:10"));
+    }
+
+    #[tokio::test]
+    async fn test_create_pull_request_via_api_success() {
+        let mock_server = MockServer::start().await;
+
+        let generator = create_test_pr_generator().await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://github.com/test-owner/test-repo/pull/123",
+                "number": 123
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let mock_url = format!("{}/repos/test-owner/test-repo", mock_server.uri());
+
+        let api_url = format!("{}/pulls", mock_url);
+        let pr_data = GitHubPullRequest {
+            title: "fix: Update broken links".to_string(),
+            body: generator.create_pr_description(),
+            head: generator.feature_branch.clone(),
+            base: generator.base_branch.clone(),
+        };
+
+        let response = generator
+            .http_client
+            .post(&api_url)
+            .header("Authorization", format!("token {}", generator.github_token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "queensac-link-fixer")
+            .json(&pr_data)
+            .send()
+            .await
+            .unwrap();
+
+        assert!(response.status().is_success());
+        let pr_response: GitHubPullRequestResponse = response.json().await.unwrap();
+        assert_eq!(
+            pr_response.html_url,
+            "https://github.com/test-owner/test-repo/pull/123"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_pull_request_via_api_failure() {
+        let mock_server = MockServer::start().await;
+
+        let generator = create_test_pr_generator().await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Bad credentials",
+                "documentation_url": "https://docs.github.com/rest"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let mock_url = format!("{}/repos/test-owner/test-repo", mock_server.uri());
+        let api_url = format!("{}/pulls", mock_url);
+        let pr_data = GitHubPullRequest {
+            title: "fix: Update broken links".to_string(),
+            body: generator.create_pr_description(),
+            head: generator.feature_branch.clone(),
+            base: generator.base_branch.clone(),
+        };
+
+        let response = generator
+            .http_client
+            .post(&api_url)
+            .header("Authorization", format!("token {}", generator.github_token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "queensac-link-fixer")
+            .json(&pr_data)
+            .send()
+            .await
+            .unwrap();
+
+        assert!(!response.status().is_success());
+        assert_eq!(response.status().as_u16(), 401);
+
+        let error_text = response.text().await.unwrap();
+        assert!(error_text.contains("Bad credentials"));
+    }
+
+    #[tokio::test]
+    async fn test_create_fix_pr_integration() {
+        let mock_server = MockServer::start().await;
+
+        let generator = create_test_pr_generator().await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://github.com/test-owner/test-repo/pull/456",
+                "number": 456
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Create test fixes
+        let fixes = vec![LinkFix {
+            file_path: "test.md".to_string(),
+            line_number: 3,
+            old_url: "https://broken-url.com".to_string(),
+            new_url: "https://working-url.com".to_string(),
+        }];
+
+        let result = generator.create_fix_pr(fixes).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_pr_description() {
+        let generator = create_test_pr_generator().await;
+
+        let description = generator.create_pr_description();
+
+        assert!(description.contains("## 🔗 Link Fixes"));
+        assert!(description.contains("This pull request was automatically generated"));
+        assert!(description.contains("queens.ac"));
+    }
+}

--- a/rook/src/git/repo.rs
+++ b/rook/src/git/repo.rs
@@ -1,10 +1,7 @@
-use std::{env, fs, path::PathBuf, time};
-
-//TODO 문서화 보완 지금 하자!!!
-use git2::{BranchType, Oid, Repository, Signature, build::CheckoutBuilder};
-use tracing::{error, info};
-
 use crate::{GitHubUrl, file_exists_in_repo, find_last_commit_id, track_file_rename_in_commit};
+use git2::{BranchType, Oid, Repository, Signature, build::CheckoutBuilder};
+use std::{env, fs, path::PathBuf, time};
+use tracing::{error, info};
 
 /// A guard that automatically removes a temporary directory when dropped.
 pub struct TempDirGuard {

--- a/rook/src/git/repo.rs
+++ b/rook/src/git/repo.rs
@@ -230,7 +230,7 @@ impl RepoManager {
         let parent_commit = self.repo.find_commit(head.target().unwrap())?;
 
         let commit_id = self.repo.commit(
-            Some(&head.name().unwrap()),
+            Some(head.name().unwrap()),
             &signature,
             &signature,
             message,


### PR DESCRIPTION
## ♟️ What’s this PR about?

파일을 수정하고 변경 사항에 대한 Pull Request를 생성하는 기능을 구현하였습니다. 

PR 생성 요청 흐름을 어떻게 가져가는게 아름다울지 고민해보았는데, 

일단 현 상황은 실시간으로 링크 체크를 확인할 수 있고(sse), 또 매일 메일로도 링크 체크 결과를 확인할 수 있도록 구현이 된 상태입니다. 두 가지 방식으로 작업이 끝난 다음 변경해야 하는 링크가 발견됐을 때, 이를 PR 생성기한테 전해줘야 하는데, 그냥 바로 전해주게 된다면 코드 구현이 꼬일거 같다는 생각이 들었습니다. 
그래서 두 가지 방식 모두 작업이 끝난 다음 결과를 DB에 저장하고, PR 생성 요청이 오면 DB에서 저장된 결과가 있는지 확인하고, 결과가 없다면 오류를, 결과가 있다면 그 결과를 가지고 PR을 생성하는 흐름으로 구현을 하였습니다.

비동기적이고, 사용자가 PR 생성을 하고 싶지 않는 것에 대한 핸들링도 쉽다는 장점이 있습니다.
아직 테스트가 작성되지 않았는데, 테스트에서 DB를 다뤄야 하기에 테스트의 볼륨이 조금 커질 거 같아서 테스트 작성은 이 PR 작성하지 않았고 한번 끊어서 가려고 합니다. 


## 🔗 Related Issues / PRs

part of #43 