### PR TITLE
fix: change dependabot check directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows/"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "cargo"
-    directory: "/rook"
+    directory: "/rook/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## ♟️ What’s this PR about?

github-action 체크 디렉터리를 최상위 디렉터리가 아닌 .github/workflows/ 로 변경

