### PR TITLE
refactor: move KoreanTime structure from main.rs to domain/time.rs

### DIFF
--- a/rook/src/domain/mod.rs
+++ b/rook/src/domain/mod.rs
@@ -3,9 +3,11 @@ mod email_verification_service;
 mod new_subscriber;
 mod repository_url;
 mod subscriber_email;
+mod time;
 
 pub use email_verification::*;
 pub use email_verification_service::*;
 pub use new_subscriber::*;
 pub use repository_url::*;
 pub use subscriber_email::*;
+pub use time::*;

--- a/rook/src/domain/time.rs
+++ b/rook/src/domain/time.rs
@@ -1,0 +1,32 @@
+use std::fmt;
+
+use chrono::{FixedOffset, Utc};
+use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
+
+/// The offset in seconds for Korean Standard Time (UTC+9)
+const KST_OFFSET: i32 = 9 * 3600;
+
+/// A time formatter that outputs timestamps in Korean Standard Time (KST)
+///
+/// This struct implements the `FormatTime` trait to format timestamps in KST
+/// with millisecond precision and timezone offset.
+///
+/// # Format
+/// The output format is: `YYYY-MM-DDThh:mm:ss.sss+09:00`
+///
+/// # Example
+/// ```
+/// use queensac::KoreanTime;
+/// use tracing_subscriber::fmt::time::FormatTime;
+///
+/// let formatter = KoreanTime;
+/// // Will output something like: 2024-02-14T15:30:45.123+09:00
+/// ```
+pub struct KoreanTime;
+
+impl FormatTime for KoreanTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> Result<(), fmt::Error> {
+        let now = Utc::now().with_timezone(&FixedOffset::east_opt(KST_OFFSET).unwrap());
+        write!(w, "{}", now.format("%Y-%m-%dT%H:%M:%S%.3f%:z"))
+    }
+}

--- a/rook/src/main.rs
+++ b/rook/src/main.rs
@@ -1,13 +1,10 @@
-// todo 어떤게 깔끔한 import 구조인지, 조사하기. 베스트 쁘락띠쓰 찾기.
-use queensac::Application;
 use queensac::configuration::get_configuration_with_secrets;
+use queensac::{Application, KoreanTime};
 
-use chrono::{FixedOffset, Utc};
 use shuttle_runtime::SecretStore;
 use sqlx::PgPool;
-use std::fmt;
 use tracing::{Level, info};
-use tracing_subscriber::{FmtSubscriber, fmt::format::Writer, fmt::time::FormatTime};
+use tracing_subscriber::FmtSubscriber;
 
 #[shuttle_runtime::main]
 async fn main(
@@ -36,31 +33,4 @@ async fn main(
         .expect("Failed to build application.");
 
     Ok(app.router.into())
-}
-
-/// The offset in seconds for Korean Standard Time (UTC+9)
-const KST_OFFSET: i32 = 9 * 3600;
-
-/// A time formatter that outputs timestamps in Korean Standard Time (KST)
-///
-/// This struct implements the `FormatTime` trait to format timestamps in KST
-/// with millisecond precision and timezone offset.
-///
-/// # Format
-/// The output format is: `YYYY-MM-DDThh:mm:ss.sss+09:00`
-///
-/// # Example
-/// ```
-/// use tracing_subscriber::fmt::time::FormatTime;
-///
-/// let formatter = KoreanTime;
-/// // Will output something like: 2024-02-14T15:30:45.123+09:00
-/// ```
-struct KoreanTime;
-
-impl FormatTime for KoreanTime {
-    fn format_time(&self, w: &mut Writer<'_>) -> Result<(), fmt::Error> {
-        let now = Utc::now().with_timezone(&FixedOffset::east_opt(KST_OFFSET).unwrap());
-        write!(w, "{}", now.format("%Y-%m-%dT%H:%M:%S%.3f%:z"))
-    }
 }


### PR DESCRIPTION
## ♟️ What’s this PR about?

#165 처럼 `main.rs`를 좀 더 간결하게 유지하고자 하여 로깅에 사용되는 struct의 위치를 `domain/time.rs`로 이동하였습니다. 
