### PR TITLE
CI에 tarpaulin & codecov 설정 추가

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,40 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: 50..80
+
+  status:
+    project:
+      default:
+        target: 50%          # 현재 수준으로 설정
+        threshold: 5%        # 5% 이하로 떨어지면 실패 (너무 엄격하지 않게)
+        base: auto
+        if_ci_failed: error  # CI 실패 시 커버리지 체크도 실패
+    patch:
+      default:
+        target: 60%         # 새 코드는 조금 더 높은 기준
+        threshold: 10%      # 새 코드에 대해서는 관대하게
+        base: auto
+        if_not_found: success  # 새 코드가 없으면 성공
+
+comment:
+  layout: "header, diff, flags, files, footer"
+  behavior: default
+  require_changes: true    # 변경사항이 있을 때만 코멘트
+  require_base: false
+  require_head: true
+  hide_project_coverage: false  # 프로젝트 전체 커버리지 표시
+
+# 점진적 개선을 위한 설정
+github_checks:
+  annotations: true        # GitHub에서 커버리지 누락 부분 표시
+
+# 파일별 커버리지 임계값 (점진적 개선용)
+flag_management:
+  default_rules:
+    carryforward: true     # 이전 커버리지 데이터 유지

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,3 +87,28 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: cargo test --verbose
+      
+      - name: Cache cargo-tarpaulin binary
+        id: cache-tarpaulin
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-tarpaulin
+          key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-tarpaulin
+        if: steps.cache-tarpaulin.outputs.cache-hit != 'true'
+        run: cargo install cargo-tarpaulin
+      
+      - name: Generate coverage report
+        working-directory: rook
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: cargo tarpaulin --out xml --output-dir coverage
+      
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./rook/coverage/cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## ♟️ What’s this PR about?

테스트 리포트하는 도구인 [tarpaulin](https://github.com/xd009642/tarpaulin)과 테스트 커버리지를 확인할 수 있는 도구 [codecov](https://about.codecov.io/) 설정을 추가하였습니다.

## 🔗 Related Issues / PRs

close: #167 