### PR TITLE
ci: add codecov upload to coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,3 +140,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: rust


### PR DESCRIPTION
## ♟️ What’s this PR about?

coveralls이 정신을 못차리고 있다. 그래서 codecov도 추가하여 테스트 커버리지를 확인할 수 있도록 하였다. 

## 🔗 Related Issues / PRs

part of #126 
