### PR TITLE
fix: ignore trivial redirects that only add trailing slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 config = "0.15"
 thiserror = "2.0"
 octocrab = "0.44.1"
+url = "2.5.4"
 
 [dev-dependencies]
 serial_test = "3.0.0"

--- a/src/link_checker/link.rs
+++ b/src/link_checker/link.rs
@@ -1,4 +1,5 @@
 use crate::{GitHubUrl, RepoManager};
+use url::Url;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum LinkCheckResult {
@@ -49,6 +50,9 @@ pub async fn check_link(url: &str) -> LinkCheckResult {
                     if let Some(redirect_url) = res.headers().get("location")
                         && let Ok(redirect_str) = redirect_url.to_str()
                     {
+                        if is_trivial_redirect(url, redirect_str) {
+                            return LinkCheckResult::Valid;
+                        }
                         return LinkCheckResult::Redirect(redirect_str.to_string());
                     }
                     return LinkCheckResult::Valid;
@@ -68,6 +72,35 @@ pub async fn check_link(url: &str) -> LinkCheckResult {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
     LinkCheckResult::Invalid("Max retries exceeded".to_string())
+}
+
+fn is_trivial_redirect(original: &str, redirect: &str) -> bool {
+    let orig_url = match Url::parse(original) {
+        Ok(url) => url,
+        Err(_) => return false,
+    };
+
+    let redirect_url = match Url::parse(redirect) {
+        Ok(url) => url,
+        Err(_) => return false,
+    };
+
+    if orig_url.scheme() != redirect_url.scheme()
+        || orig_url.host() != redirect_url.host()
+        || orig_url.port() != redirect_url.port()
+    {
+        return false;
+    }
+
+    if orig_url.query() != redirect_url.query() {
+        return false;
+    }
+
+    let orig_path = orig_url.path();
+    let redirect_path = redirect_url.path();
+
+    redirect_path == format!("{}/", orig_path.trim_end_matches('/'))
+        || redirect_path == orig_path.trim_end_matches('/')
 }
 
 #[cfg(test)]
@@ -112,5 +145,64 @@ mod tests {
             check_link(link).await,
             LinkCheckResult::Redirect("https://github.com/reddevilmidzy/kingsac".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn check_redirect_url() {
+        let link = "https://gluesql.org/docs";
+        assert_eq!(
+            check_link(link).await,
+            LinkCheckResult::Valid,
+            "check trivial redirect"
+        );
+        let link = "https://gluesql.org/docs/";
+        assert_eq!(
+            check_link(link).await,
+            LinkCheckResult::Valid,
+            "check trivial redirect"
+        );
+    }
+
+    #[test]
+    fn test_is_trivial_redirect() {
+        // Basic trailing slash cases
+        assert!(is_trivial_redirect(
+            "https://example.com",
+            "https://example.com/"
+        ));
+        assert!(is_trivial_redirect(
+            "https://example.com/",
+            "https://example.com"
+        ));
+
+        // Multiple trailing slashes should not be considered trivial
+        assert!(!is_trivial_redirect(
+            "https://example.com",
+            "https://example.com//"
+        ));
+
+        // Different paths should not be trivial
+        assert!(!is_trivial_redirect(
+            "https://example.com/docs",
+            "https://example.com/guides"
+        ));
+
+        // Query parameters should not affect trivial redirect detection
+        assert!(is_trivial_redirect(
+            "https://example.com?q=test",
+            "https://example.com/?q=test"
+        ));
+
+        // Different query parameters should not be trivial
+        assert!(!is_trivial_redirect(
+            "https://example.com/?q=test",
+            "https://example.com/?q=test&p=1"
+        ));
+
+        // Different ports should not be trivial
+        assert!(!is_trivial_redirect(
+            "https://example.com:8080",
+            "https://example.com:8081"
+        ));
     }
 }


### PR DESCRIPTION
## ♟️ What’s this PR about?

리다이렉트될때 host에 단순히 `/`만 추가되어 리다이렉트되는 경우 redirect로 처리하지 않고 valid로 처리하도록 코드를 수정하였습니다.


## 🔗 Related Issues / PRs
close: #186 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved link checking to treat redirects that only add or remove a trailing slash as valid, reducing unnecessary redirect warnings.
* **Bug Fixes**
  * Reduced the link check timeout from 10 seconds to 3 seconds, making link validation faster.
* **Chores**
  * Updated dependencies to include the latest version of the URL parsing library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->