### PR TITLE
refactor: change request timeout

### DIFF
--- a/src/link_checker/link.rs
+++ b/src/link_checker/link.rs
@@ -34,7 +34,7 @@ fn handle_github_404(url: &str) -> LinkCheckResult {
 
 pub async fn check_link(url: &str) -> LinkCheckResult {
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(5))
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap();


### PR DESCRIPTION
## ♟️ What’s this PR about?

요청 타임아웃이 10초의 타임아웃은 너무 길다고 생각되어 5초로 단축시켰습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced the timeout duration for link checking from 10 seconds to 5 seconds, resulting in faster feedback for users when checking links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->