### PR TITLE
fix: Change Dependabot cargo update interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## ♟️ What’s this PR about?

change interval from daily to weekly. ~~it happened too often~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to check for dependency updates weekly instead of daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->