### PR TITLE
fix: Update author details in PullRequestGenerator to use bot account

### DIFF
--- a/src/git/pr_generator.rs
+++ b/src/git/pr_generator.rs
@@ -258,8 +258,8 @@ impl PullRequestGenerator {
         for change in changes {
             self.repo_manager.add_file(&change.file_path).await?;
         }
-        let author_name = "queensac";
-        let author_email = "noreply@queens.ac";
+        let author_name = "queensac[bot]";
+        let author_email = "218335951+queensac[bot]@users.noreply.github.com";
 
         let commit_message = self.create_commit_message(changes);
 


### PR DESCRIPTION
## ♟️ What’s this PR about?

This pull request updates the author information used when generating pull requests in the `PullRequestGenerator` implementation. The changes ensure the commit author matches the expected bot identity for automated commits.

Authentication and identity update:

* Changed the commit author name to `"queensac[bot]"` and the email to the corresponding GitHub bot address in `src/git/pr_generator.rs`, ensuring commits are correctly attributed to the bot account.
<img width="1385" height="335" alt="image" src="https://github.com/user-attachments/assets/7e216ea2-45d0-4330-8484-89eaa299e280" />

<br>

https://github.com/reddevilmidzy/kingsac/pull/19/commits/359aa47f9d2004446e05141081c5eb6407943dfc


## 🔗 Related Issues / PRs

resolve: #261 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized commit author metadata for auto-generated commits to use the bot identity and noreply address. This improves attribution clarity in commit history, aligns with repository policies, and reduces accidental notifications. There are no changes to app behavior, features, or error handling. End users should not notice any functional differences; only commit history will reflect the updated author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->