### PR TITLE
refactor: Use millisecond timestamp for branch name

### DIFF
--- a/src/git/pr_generator.rs
+++ b/src/git/pr_generator.rs
@@ -363,8 +363,8 @@ This pull request was automatically generated to fix broken links in the reposit
 fn generate_branch_name() -> String {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
     format!("queensac-{}", now)
 }
 


### PR DESCRIPTION
## ♟️ What’s this PR about?

Generate branch names using milliseconds since the UNIX epoch to keep higher resolution and use unwrap_or(0) to avoid panicking if the system clock is before the UNIX_EPOCH

## 🔗 Related Issues / PRs

close: #279 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timestamp precision handling in branch name generation with enhanced fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->