### PR TITLE
docs: add MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 repository = "https://github.com/reddevilmidzy/queensac"
 license = "Apache-2.0"
 readme = "README.md"
+rust-version = "1.88.0"
 
 [dependencies]
 regex = "1.12"


### PR DESCRIPTION

## ♟️ What’s this PR about?

- Adds `rust-version = "1.88.0"` to Cargo.toml. 


## 🔗 Related Issues / PRs

Closes #290 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to specify minimum Rust version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->