### PR TITLE
refactor: Remove file, line, and thread names from logger

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ fn main() {
     tracing_subscriber::fmt()
         .with_max_level(Level::INFO)
         .with_target(false)
-        .with_thread_ids(true)
         .with_level(true)
         .with_ansi(true)
         .with_timer(KoreanTime)


### PR DESCRIPTION
## ♟️ What’s this PR about?

This pull request makes a small adjustment to the logging configuration in `src/main.rs`. The change removes the inclusion of file names, line numbers, and thread names from the log output. This will result in cleaner and more concise logs.

## 🔗 Related Issues / PRs

resolve: #300 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced log verbosity by removing file/line and thread identifiers from log output.
  * Kept log level, color/ANSI styling, timestamps, and human-readable formatting intact for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->